### PR TITLE
Add support for year placeholder

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,18 +1,20 @@
 go-license
 ==========
-`go-license` is a tool that ensures that a license header is applied to all Go files in a project.
+`go-license` is a tool that ensures that a license header is applied to Go files.
 
 Usage
 -----
-Run `./go-license --config=license.yml` to apply the license specified by the configuration in `license.yml` to all of
-the `*.go` files rooted in the current working directory.
+Run `./go-license --config=license.yml [files]` to apply the license specified by the configuration in `license.yml` to
+all of the specified files (only the files that end in `.go` and are not excluded by configuration are processed).
 
-Run `./go-license --config=license.yml --verify` to verify that the license specified by the configuration is applied to
-all of the `*.go` files rooted in the current working directory. If the license is not applied properly to any of the
-files, the files that do not match are printed and the program exits with a non-0 exit code.
+Run `./go-license --config=license.yml --remove [files]` to remove the license specified by the configuration in
+`license.yml` from all of the specified files (only the files that end in `.go` and are not excluded by configuration
+are processed).
 
-Alternatively, a list of files to format may be provided as arguments. The `exclude` filter specified in configuration
-will still be applied to paths that are provided as arguments.
+Run `./go-license --config=license.yml --verify [files]` to verify that the license specified by the configuration is
+applied to all of the specified files `*.go` files (only the files that end in `.go` and are not excluded by
+configuration are processed). If the license is not applied properly to any of the files, the files that do not match
+are printed and the program exits with a non-0 exit code.
 
 Configuration
 -------------
@@ -23,25 +25,37 @@ Here is an example configuration file:
 
 ```yml
 header: |
-        /*
-        Copyright 2016 Palantir Technologies, Inc.
+  // Copyright {{YEAR}} Palantir Technologies, Inc.
+  //
+  // Licensed under the Apache License, Version 2.0 (the "License");
+  // you may not use this file except in compliance with the License.
+  // You may obtain a copy of the License at
+  //
+  //     http://www.apache.org/licenses/LICENSE-2.0
+  //
+  // Unless required by applicable law or agreed to in writing, software
+  // distributed under the License is distributed on an "AS IS" BASIS,
+  // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  // See the License for the specific language governing permissions and
+  // limitations under the License.
 
-        Licensed under the Apache License, Version 2.0 (the "License");
-        you may not use this file except in compliance with the License.
-        You may obtain a copy of the License at
+custom-headers:
+  - name: subproject
+    header: |
+      // Copyright 2016 Palantir Technologies, Inc. All rights reserved.
+      // Subproject license.
 
-        http://www.apache.org/licenses/LICENSE-2.0
-
-        Unless required by applicable law or agreed to in writing, software
-        distributed under the License is distributed on an "AS IS" BASIS,
-        WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-        See the License for the specific language governing permissions and
-        limitations under the License.
-        */
+    paths:
+      - subprojectDir
 exclude:
   exclude-names:
     - "vendor"
 ```
+
+The string `{{YEAR}}` indicates that, when a license is added by the tool, the current year will be used. For operations
+that match licenses (for verification or removal), `{{YEAR}}` will match any 4-digit number.
+
+The `custom-headers` configuration allows custom headers to be specified for matching names or paths.
 
 go-license-plugin
 =================

--- a/godelplugin/integration_test/integration_test.go
+++ b/godelplugin/integration_test/integration_test.go
@@ -22,6 +22,7 @@ import (
 	"path"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/nmiyake/pkg/dirs"
 	"github.com/nmiyake/pkg/gofiles"
@@ -49,7 +50,7 @@ func TestLicense(t *testing.T) {
 
 	const licenseYML = `header: |
   /*
-  Copyright 2016 Palantir Technologies, Inc.
+  Copyright {{YEAR}} Palantir Technologies, Inc.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -86,8 +87,8 @@ func TestLicense(t *testing.T) {
 	files, err := gofiles.Write(projectDir, specs)
 	require.NoError(t, err)
 
-	want := `/*
-Copyright 2016 Palantir Technologies, Inc.
+	want := fmt.Sprintf(`/*
+Copyright %d Palantir Technologies, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -102,7 +103,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package foo`
+package foo`, time.Now().Year())
 
 	outputBuf := &bytes.Buffer{}
 	runPluginCleanup, err := pluginapitester.RunPlugin(pluginPath, nil, "license", nil, projectDir, false, outputBuf)
@@ -129,7 +130,7 @@ func TestLicenseVerify(t *testing.T) {
 
 	const licenseYML = `header: |
   /*
-  Copyright 2016 Palantir Technologies, Inc.
+  Copyright {{YEAR}} Palantir Technologies, Inc.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.


### PR DESCRIPTION
If "{{YEAR}}" is specified in a license template, it is replaced
with the current year when adding licenses and matches any 4-digit
year when verifying or removing licenses.