### PR TITLE
Problem: go-license fails with example config

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ custom-headers:
     paths:
       - subprojectDir
 exclude:
-  exclude-names:
+  names:
     - "vendor"
 ```
 


### PR DESCRIPTION
When used with a config similar to the one in README, go-license fails with:

```
Error: failed to read file .license.yml: failed to unmarshal license-plugin v0 configuration: yaml: unmarshal errors:
  line 12: field exclude-names not found in type matcher.NamesPathsCfg
```

Solution: change `exclude-names` to `names` as this is how it is

## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

